### PR TITLE
Added support for external logging domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,5 @@ FROM_EMAIL = ""
 FROM_EMAIL_NAME = ""
 TO_EMAIL = ""
 TO_EMAIL_NAME = ""
+LOGGER_DOMAIN = ""
 ```

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ async function logHell(request) {
         {
           type: 'text/plain',
           value:
-            'View the log of their painful password attempts here: ' + LOGGER_DOMAIN ?? "https://passwordpurgatory.com" + '/get-hell?kvKey=' +
+            'View the log of their painful password attempts here: ' + LOGGER_DOMAIN != null ? LOGGER_DOMAIN : "https://passwordpurgatory.com" + '/get-hell?kvKey=' +
             kvKey,
         },
       ],

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ async function logHell(request) {
         {
           type: 'text/plain',
           value:
-            'View the log of their painful password attempts here: ' + LOGGER_DOMAIN != null ? LOGGER_DOMAIN : "https://passwordpurgatory.com" + '/get-hell?kvKey=' +
+            'View the log of their painful password attempts here: ' + (typeof LOGGER_DOMAIN !== 'undefined' ? LOGGER_DOMAIN : "https://passwordpurgatory.com") + '/get-hell?kvKey=' +
             kvKey,
         },
       ],

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ async function logHell(request) {
         {
           type: 'text/plain',
           value:
-            'View the log of their painful password attempts here: https://passwordpurgatory.com/get-hell?kvKey=' +
+            'View the log of their painful password attempts here: ' + LOGGER_DOMAIN ?? "https://passwordpurgatory.com" + '/get-hell?kvKey=' +
             kvKey,
         },
       ],


### PR DESCRIPTION
As part of https://github.com/troyhunt/password-purgatory/pull/13 I have also added the ability to add a new ENV to point to the users logger worker domain
<html>
<body>
<!--StartFragment-->

LOGGER_DOMAIN | https://my-password-purgatory-logger.my-username.workers.dev
-- | --


<!--EndFragment-->
</body>
</html>

So this way when the user gets an email about a new spammer being hooked, the link they click to access the logs is correct
