### PR TITLE
HTML encoding for external string values

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,9 +168,9 @@ async function getHell(request) {
     // meta description as it'll probably be the funniest 🤣
     pageTitle = 'Password Purgatory - Making Life Hell for Spammers'
     pageDescription =
-      history[history.length - 1].criteria +
+      escapeHtml(history[history.length - 1].criteria) +
       ': ' +
-      history[history.length - 1].password
+      escapeHtml(history[history.length - 1].password)
     pageContents =
       '<h1>Spammer made ' +
       history.length +
@@ -190,10 +190,10 @@ async function getHell(request) {
               ` seconds later)`) +
           `</h2>
       <dl><dt>Criteria:</dt> <dd>` +
-          (attempt.criteria === '' ? '[none]' : attempt.criteria) +
+          (escapeHtml(attempt.criteria) === '' ? '[none]' : escapeHtml(attempt.criteria)) +
           `</dd>
       <dt>Password:</dt> <dd>` +
-          attempt.password +
+      escapeHtml(attempt.password) +
           `</dd></dl></li>
       `),
     )
@@ -239,5 +239,22 @@ async function getHell(request) {
   return new Response(html, {
     headers: { 'Content-type': 'text/html;charset=UTF-8' },
     status: status,
+  })
+}
+
+const htmlEntityMap = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+  '`': '&#96;',
+  '/': '&#x2F;',
+}
+
+function escapeHtml (str) {
+  const r = /[&<>"'`=\/]/g
+  return str.replace(r, (s) => {
+    return htmlEntityMap[s]
   })
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,5 +5,5 @@ workers_dev = true
 compatibility_date = "2022-07-24"
 
 kv_namespaces = [
-         { binding = "PASSWORD_PURGATORY", id = "5a31f18ea0c74e8b9dda010373b05e0e", preview_id = "16eb5cae3508418c875a7f8950e09a68" }
+         { binding = "PASSWORD_PURGATORY", id = "b2e505e33ddb4cc5ae3672efc57e7e9d", preview_id = "b2e505e33ddb4cc5ae3672efc57e7e9d" }
 ]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,5 +5,5 @@ workers_dev = true
 compatibility_date = "2022-07-24"
 
 kv_namespaces = [
-         { binding = "PASSWORD_PURGATORY", id = "b2e505e33ddb4cc5ae3672efc57e7e9d", preview_id = "b2e505e33ddb4cc5ae3672efc57e7e9d" }
+         { binding = "PASSWORD_PURGATORY", id = "5a31f18ea0c74e8b9dda010373b05e0e", preview_id = "16eb5cae3508418c875a7f8950e09a68" }
 ]


### PR DESCRIPTION
Assumption is that the HTML encoding is for the user submitted values (and the generated criteria), in order to prevent injection and an ugly get-hell page.